### PR TITLE
[3] - Include docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 /.idea/
+.phpunit.result.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM php:8.2-cli-alpine
+
+RUN apk update && \
+    apk add zsh git vim zsh-autosuggestions zsh-syntax-highlighting bind-tools openssh curl && \
+    rm -rf /var/cache/apk/*
+RUN sh -c "$(wget https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh -O -)"
+RUN echo "source /usr/share/zsh/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" >> ~/.zshrc && \
+echo "source /usr/share/zsh/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh" >> ~/.zshrc \
+echo "cd /home/php/cleanCode" >> ~/.zshrc
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+RUN mkdir cleanCode

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
-PHP 8 testing base
+# PHP 8.2 docker base image and testing base
 
-Run: composer install
+By default git, composer, php8.2 and Zsh are installed
+
+The project can be mounted using docker:
+ - Start docker daemon
+ - Run: docker-compose up -d
+ - To go into the container: docker exec -it php8.2 /bin/zsh
+ - Project is on /home/php/CleanCode
+ - To execute test: ./vendor/phpunit/phpunit/phpunit
+ - To stop de container: docker-compose stop

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+
+services:
+  php:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: php8.2
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/home/php/cleanCode

--- a/src/Calculator.php
+++ b/src/Calculator.php
@@ -6,11 +6,11 @@ class Calculator
 {
     function add(int $number1, int $number2): int
     {
-        return 0;
+        return $number1 + $number2;
     }
 
     function multiply(int $number1, int $number2): int
     {
-        return 0;
+        return $number1 * $number2;
     }
 }


### PR DESCRIPTION
It generates a docker image with:
 - php8.2
 - zsh with the plugins zsh-syntax-highlighting and zsh-autosuggestions
 - composer

This image can be used for launch test with out modify own computers